### PR TITLE
Update loggly.go

### DIFF
--- a/loggly.go
+++ b/loggly.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"time"
 
-	color "github.com/TwinProduction/go-color"
+	color "github.com/TwiN/go-color"
 )
 
 // Loggly API URL


### PR DESCRIPTION
Updated dependency path for color library from "github.com/TwinProduction/go-color" to "github.com/TwiN/go-color" as presented in Twin's github documentation.
Reference: https://github.com/TwiN/go-color